### PR TITLE
Fix fseek_ and ftell_ on Win32

### DIFF
--- a/stdc.mod/stdc.c
+++ b/stdc.mod/stdc.c
@@ -190,11 +190,15 @@ int system_( BBString *cmd ){
 }
 
 int fseek_( FILE* stream, BBLONG offset, int origin ) {
+	// flush stream when using _fileno
+	fflush(stream);
 	int f = _fileno(stream);
 	return (_lseeki64(f, offset, origin) >= 0) ? 0 : 1;
 }
 
 BBLONG ftell_( FILE* stream ) {
+	// flush stream when using _fileno
+	fflush(stream);
 	int f = _fileno(stream);
 	return _telli64(f);
 }


### PR DESCRIPTION
- on Windows fseek_ returned always "the end" of a stream, added "fflush" to make it work again

More details can be found here:
http://www.tek-tips.com/viewthread.cfm?qid=1234654
https://code.google.com/p/mp4v2/source/browse/trunk/libplatform/io/File_win32.cpp?r=295

So it seems the correct way of fixing it.
