### PR TITLE
Feature: OggDecoder - Read_Ogg() returns read bytes instead of "0"

### DIFF
--- a/oggvorbis.mod/oggdecoder.c
+++ b/oggvorbis.mod/oggdecoder.c
@@ -59,9 +59,11 @@ void *Decode_Ogg(void *stream,void *oread,void *oseek,void *oclose,void *otell,i
 
 int Read_Ogg(oggio *ogg,char *buf,int bytes)	// null buffer to close
 {
-	int		res,bs;
+	int		res,bs,bytesRead;
 
 	if (buf==0) return ov_clear(&ogg->vf);
+
+	bytesRead = 0;
 
 	while (bytes>0)
 	{
@@ -71,8 +73,13 @@ int Read_Ogg(oggio *ogg,char *buf,int bytes)	// null buffer to close
 			if (bs) return -1;	// Only one logical bitstream currently supported
 			return -2;			// Warning: hole in data
 		}
+		else if (res == 0) // reached eof
+		{
+			return bytesRead;
+		}
+		bytesRead+=res;
 		buf+=res;
 		bytes-=res;
 	}
-	return 0;
+	return bytesRead;
 }


### PR DESCRIPTION
Before: Read_Ogg() returned 0 for all operations except errors (negative numbers)

Now: Read_Ogg() returns the amount of read bytes (might be less than the desired amount given in param "bytes" - when EOF was reached earlier). It correctly returns "0" when closing (ov_close() returns 0 on success, no other return value given in the vorbisfile.c). And negative values are returned on error.
So the corrected Reag_Ogg() returns similar values compared to the underlying ov_read() function)