### PR TITLE
[FreeProcess] Add SHOWCONSOLE flag support to CreateProcess()

### DIFF
--- a/freeprocess.mod/freeprocess.bmx
+++ b/freeprocess.mod/freeprocess.bmx
@@ -46,7 +46,10 @@ Function fdTerminateProcess:Int(processhandle:Size_T)
 Function fdKillProcess:Int(processhandle:Size_T)
 End Extern
 
+'explicitely hide a possibly shown console
 Const HIDECONSOLE:Int=1
+'explicitely show a (new) console
+Const SHOWCONSOLE:Int=2
 
 Type TPipeStream Extends TStream
 

--- a/freeprocess.mod/freeprocess.c
+++ b/freeprocess.mod/freeprocess.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 
 #define HIDECONSOLE 1
+#define SHOWCONSOLE 2
 
 #if __APPLE__ || __linux || __HAIKU__
 
@@ -337,8 +338,11 @@ size_t fdProcess( BBString *cmd,size_t *procin,size_t *procout,size_t *procerr,i
 		if (flags&HIDECONSOLE) {
 			si.dwFlags|=STARTF_USESHOWWINDOW;
 			si.wShowWindow=SW_HIDE;
-		}
-		else {
+		} 
+		else if (flags&SHOWCONSOLE) {
+			pflags|=CREATE_NEW_CONSOLE;
+    	} 
+    	else {
 			pflags|=DETACHED_PROCESS;
 		}
 		BBChar *c = bbStringToWString(cmd);
@@ -355,6 +359,9 @@ size_t fdProcess( BBString *cmd,size_t *procin,size_t *procout,size_t *procerr,i
 		if (flags&HIDECONSOLE) {
 			si.dwFlags|=STARTF_USESHOWWINDOW;
 			si.wShowWindow=SW_HIDE;
+		} 
+		else if (flags&SHOWCONSOLE) {
+			pflags|=CREATE_NEW_CONSOLE;
 		}
 		else {
 			pflags|=DETACHED_PROCESS;


### PR DESCRIPTION
This new flag creates a new process with the CREATE_NEW_CONSOLE flag.
Works on Windows only.

Closes #47