### PR TITLE
fixed: TPipeStream::ReadLine would occasionally segfault

### DIFF
--- a/freeprocess.mod/freeprocess.bmx
+++ b/freeprocess.mod/freeprocess.bmx
@@ -100,7 +100,7 @@ Type TPipeStream Extends TStream
 			r=Read(Varptr readbuffer[bufferpos],n)
 			bufferpos:+r
 		EndIf
-		For n=0 To bufferpos
+		For n=0 Until bufferpos
 			If readbuffer[n]=10
 				p1=n
 				If (n>0)


### PR DESCRIPTION
It was reading a byte past the currently read buffer, and if this happened to contain a linefeed character (which happened rarely) the bufferpos would be subtracted down to -1, resulting in an erroneous memmove size