### PR TITLE
Added CurrentUnixTime() function.

### DIFF
--- a/stdc.mod/stdc.bmx
+++ b/stdc.mod/stdc.bmx
@@ -450,7 +450,13 @@ Rem
 bbdoc: Returns the current date and time.
 End Rem
 Function CurrentDateTime(dt:SDateTime Var, utc:Int = True)="bmx_current_datetime"
-	
+
+Rem
+bbdoc: Returns the current Unix time in milliseconds.
+about: The Unix time is a system for describing a point in time, defined as the number of seconds that have
+elapsed since 00:00:00 Coordinated Universal Time (UTC), Thursday, 1 January 1970, minus the number of leap seconds.
+End Rem
+Function CurrentUnixTime:ULong()="bmx_current_unix_time"
 
 End Extern
 

--- a/stdc.mod/stdc.c
+++ b/stdc.mod/stdc.c
@@ -1097,6 +1097,17 @@ void bmx_current_datetime(SDateTime * dt, int utc) {
     dt->utc = utc;
     dt->offset = utc ? 0 : bmx_calc_timeoffset_mins(dt);
 }
+
+BBULONG bmx_current_unix_time() {
+	SYSTEMTIME systemTime;
+	GetSystemTime(&systemTime);
+	FILETIME fileTime;
+	SystemTimeToFileTime(&systemTime, &fileTime);
+	ULARGE_INTEGER uli;
+	uli.LowPart = fileTime.dwLowDateTime;
+	uli.HighPart = fileTime.dwHighDateTime;
+	return (uli.QuadPart / 10000) - 11644473600000ULL;
+}
 #else
 int bmx_calc_timeoffset_mins() {
 	time_t rawtime;
@@ -1142,6 +1153,12 @@ void bmx_current_datetime(SDateTime * dt, int utc) {
     dt->millisecond = ts.tv_nsec / 1000000;
     dt->utc = utc;
     dt->offset = utc ? 0 : bmx_calc_timeoffset_mins();
+}
+
+BBULONG bmx_current_unix_time() {
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
+	return (BBULONG)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 #endif
 


### PR DESCRIPTION
Returns current time from epoch as a ULong.