### PR TITLE
Fixes process output data loss and adds Eof() method

### DIFF
--- a/freeprocess.mod/freeprocess.bmx
+++ b/freeprocess.mod/freeprocess.bmx
@@ -5,13 +5,16 @@ bbdoc: System/Execute Processes
 End Rem
 Module Pub.FreeProcess
 
-ModuleInfo "Version: 1.04"
+ModuleInfo "Version: 1.05"
 ModuleInfo "Framework: FreeProcess multi platform external process control"
 ModuleInfo "License: zlib/libpng"
 ModuleInfo "Copyright: Blitz Research Ltd"
 ModuleInfo "Author: Simon Armstrong"
 ModuleInfo "Modserver: BRL"
 
+ModuleInfo "History: 1.05"
+ModuleInfo "History: Added Eof() method to TPipeStream."
+ModuleInfo "History: Fixed issues with losing data at end of process output."
 ModuleInfo "History: 1.04 Release"
 ModuleInfo "History: Added Documentation, Added Detach and Attach Process Functions"
 ModuleInfo "History: 1.03 Release"
@@ -40,6 +43,7 @@ Extern
 	Function fdWrite:Long(fd:Size_T,buffer:Byte Ptr,count:Long)
 	Function fdFlush(fd:Size_T)
 	Function fdAvail:Int(fd:Size_T)
+	Function fdEof:Int(fd:Size_T)
 ?win32
 	Function fdProcess:Byte Ptr(exe:String,in_fd:Size_T Ptr,out_fd:Size_T Ptr,err_fd:Size_T Ptr,flags:Int)="fdProcess"
 	Function fdProcessStatus:Int(processhandle:Byte Ptr)
@@ -94,7 +98,7 @@ Type TPipeStream Extends TStream
 	Method ReadPipe:Byte[]()
 		Local bytes:Byte[],n:Int
 		n=ReadAvail()
-		If n
+		If n > 0 Then
 			bytes=New Byte[n]
 			Read(bytes,n)
 			Return bytes
@@ -125,6 +129,20 @@ Type TPipeStream Extends TStream
 				Return line
 			EndIf
 		Next
+
+		' No newline found. If pipe is EOF and we have buffered bytes, return them as final line.
+		If bufferpos > 0 And fdEof(readhandle) Then
+			Local line:String = String.FromBytes(Varptr readbuffer[0], Int(bufferpos))
+			bufferpos = 0
+			Return line
+		EndIf
+	End Method
+
+	Method Eof:Int() Override
+		' EOF is true only when the OS says pipe is closed AND we have no buffered bytes left
+		If bufferpos > 0 Then Return False
+		If readhandle = 0 Then Return True
+		Return fdEof(readhandle) <> 0
 	End Method
 
 	Function Create:TPipeStream( in:Size_T,out:Size_T )

--- a/freeprocess.mod/freeprocess.c
+++ b/freeprocess.mod/freeprocess.c
@@ -13,12 +13,42 @@
 #include <unistd.h>
 #include <sys/wait.h>
 #include <signal.h>
+#include <poll.h>
 
 int fdClose(size_t fd) {return close(fd);}
 BBLONG fdRead(size_t fd,char *buffer,BBLONG count) {return read(fd,buffer,count);}
 BBLONG fdWrite(size_t fd,char *buffer,BBLONG count) {return write(fd,buffer,count);}
-int fdAvail(size_t fd) {int avail;if (ioctl(fd,FIONREAD,&avail)) avail=avail;return avail;}
+int fdAvail(size_t fd) {
+    int avail = 0;
+    if (ioctl((int)fd, FIONREAD, &avail) != 0) return 0;
+    return avail;
+}
 int fdFlush(size_t fd) { return 0;}//flush(fd);}
+
+int fdEof(size_t fd)
+{
+    struct pollfd pfd;
+    pfd.fd = (int)fd;
+    pfd.events = POLLIN;
+    pfd.revents = 0;
+
+    int pr = poll(&pfd, 1, 0);
+    if (pr <= 0) {
+        return 0; // no event (or error) => assume not EOF
+    }
+
+    // If writer closed, we usually get POLLHUP.
+    if (pfd.revents & POLLHUP) {
+        // Only call it EOF if there's no data left to read right now.
+        int avail = 0;
+        if (ioctl((int)fd, FIONREAD, &avail) == 0) {
+            return avail == 0;
+        }
+        return 0;
+    }
+
+    return 0;
+}
 
 ///return 1 for running, 0 for finished
 //
@@ -218,6 +248,26 @@ int fdClose(size_t fd)
 	return CloseHandle((HANDLE)fd);
 }
 
+int fdEof(size_t fd)
+{
+    DWORD avail = 0;
+
+    // If PeekNamedPipe succeeds, the pipe is still connected.
+    // EOF is only true if there are no bytes available AND the writer is gone.
+    // Unfortunately PeekNamedPipe doesn't directly say "writer gone" when it succeeds.
+    // But when the writer has closed, PeekNamedPipe will fail with ERROR_BROKEN_PIPE.
+    if (PeekNamedPipe((HANDLE)fd, NULL, 0, NULL, &avail, NULL)) {
+        return 0; // not EOF (pipe still valid)
+    }
+
+    DWORD err = GetLastError();
+    if (err == ERROR_BROKEN_PIPE || err == ERROR_PIPE_NOT_CONNECTED) {
+        return 1; // EOF
+    }
+
+    return 0; // treat other errors as "not EOF"
+}
+
 BBLONG fdRead(size_t fd,char *buffer,BBLONG bytes)
 {
 	int		res;
@@ -303,6 +353,7 @@ PROCESS_INFORMATION * fdProcess( BBString *cmd,size_t *procin,size_t *procout,si
 		//unable to create pipe
 		return 0;
 	}
+	SetHandleInformation( istr, HANDLE_FLAG_INHERIT, 0 );
 
 	if( !CreatePipe( &p_istr,&ostr,&sa,0 ) ){
 		CloseHandle( istr );
@@ -310,6 +361,7 @@ PROCESS_INFORMATION * fdProcess( BBString *cmd,size_t *procin,size_t *procout,si
 		//ditto
 		return 0;
 	}
+	SetHandleInformation( ostr, HANDLE_FLAG_INHERIT, 0 );
 
 	if (!CreatePipe(&estr,&p_estr,&sa,0)) {
 		CloseHandle( istr );
@@ -319,6 +371,7 @@ PROCESS_INFORMATION * fdProcess( BBString *cmd,size_t *procin,size_t *procout,si
 		//unable to create pipe
 		return 0;
 	}
+	SetHandleInformation( estr, HANDLE_FLAG_INHERIT, 0 );
 
 	pi=(PROCESS_INFORMATION*)calloc(1,sizeof(PROCESS_INFORMATION));
 


### PR DESCRIPTION
Tries to prevent data loss at the end of process output, specifically when the stream does not terminate with a newline character.